### PR TITLE
Add granular control over pan/zoom gestures and hotkeys

### DIFF
--- a/src/components/Pan.js
+++ b/src/components/Pan.js
@@ -12,13 +12,16 @@ export default (Wrapped) => class Pan extends Component {
     onPanStart: PropTypes.func,
     onPanMove: PropTypes.func,
     onPanEnd: PropTypes.func,
-    captureEvents: PropTypes.bool.isRequired,
+    panKeyEnabled: PropTypes.bool,
+    panKeyPreventsDefault: PropTypes.bool,
   };
 
   static defaultProps = {
     onPanStart: () => {},
     onPanMove: () => {},
     onPanEnd: () => {},
+    panKeyEnabled: true,
+    panKeyPreventsDefault: true,
   };
 
   state = {};
@@ -34,13 +37,14 @@ export default (Wrapped) => class Pan extends Component {
   }
 
   handleKeyDown = (e) => {
-    if (!this.props.captureEvents) return
-
+    const {panKeyEnabled, panKeyPreventsDefault} = this.props
     const {panMode, panning, cursor} = this.state
 
-    if (e.code === 'Space') {
-      e.preventDefault()
-      e.stopPropagation()
+    if (panKeyEnabled && e.code === 'Space') {
+
+      if (panKeyPreventsDefault) {
+        e.preventDefault()
+      }
 
       if (!panMode) {
         this.setState({panMode: true})
@@ -53,11 +57,14 @@ export default (Wrapped) => class Pan extends Component {
   }
 
   handleKeyUp = (e) => {
+    const {panKeyEnabled, panKeyPreventsDefault} = this.props
     const {panMode, panning} = this.state
 
-    if (e.code === 'Space') {
-      e.preventDefault()
-      e.stopPropagation()
+    if (panKeyEnabled && e.code === 'Space') {
+
+      if (panKeyPreventsDefault) {
+        e.preventDefault()
+      }
 
       if (panMode) {
         this.setState({panMode: false})


### PR DESCRIPTION
It's impossible to predict how these hotkeys/gestures will be used, so I figure it's best to make them all configurable.

In Deco we will just set `panKeyPreventsDefault={false}`. This doesn't affect us (since we're a single page app, space key doesn't scroll)
